### PR TITLE
Remove dependency on Phathom

### DIFF
--- a/eflash_2018/detect_blobs.py
+++ b/eflash_2018/detect_blobs.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 import scipy.ndimage as ndi
 import glob
-from phathom.utils import SharedMemory
+from eflash_2018.utils.shared_memory import SharedMemory
 import tifffile
 import tqdm
 


### PR DESCRIPTION
PR removes left over dependency on phathom in `detect_blobs.py`.